### PR TITLE
Fixes issue when used in transparent themes

### DIFF
--- a/text-divider-row.js
+++ b/text-divider-row.js
@@ -33,20 +33,24 @@ class TextDividerRow extends LitElement {
     return html`
       <style>
         .text-divider {
-          margin: 2em 0;
+          margin: 1em 0;
           line-height: 0;
           text-align: center;
+          white-space: nowrap;
+          display: flex;
+          align-items: center;
         }
         .text-divider span {
-          background-color: var(--paper-card-background-color);
           padding: 1em;
           color: var(--secondary-text-color);
         }
-        .text-divider:before {
-          content: " ";
+        .text-divider:before,
+        .text-divider:after  {
+          content: '';
+          background: var(--secondary-text-color);
           display: block;
-          border-top: 1px solid var(--secondary-text-color);
-          border-bottom: 1px solid var(--paper-card-background-color);
+          height: 1px;
+          width: 100%;
         }
       </style>
     `;


### PR DESCRIPTION
Fixes issue reported here: https://community.home-assistant.io/t/lovelace-text-divider-row/111301/3?u=kalkih

| Before | After |
|--------|------|
|![hyperion_8123_lovelace_4 copy](https://user-images.githubusercontent.com/457678/56369467-b3a1ff00-61f9-11e9-9c7d-642a71f321d8.png) | ![hyperion_8123_lovelace_4](https://user-images.githubusercontent.com/457678/56369474-b7358600-61f9-11e9-8157-2fa94154174c.png)

